### PR TITLE
Check Nexpose API response status code

### DIFF
--- a/pkg/handlers/v1/notification.go
+++ b/pkg/handlers/v1/notification.go
@@ -73,6 +73,6 @@ func (h *NotificationHandler) Handle(ctx context.Context) (Output, error) {
 func completedScanToScanNotification(scan domain.CompletedScan) scanNotification {
 	return scanNotification{
 		ScanID: scan.ScanID,
-		SiteID: scan.ScanID,
+		SiteID: scan.SiteID,
 	}
 }

--- a/pkg/handlers/v1/notification_test.go
+++ b/pkg/handlers/v1/notification_test.go
@@ -49,7 +49,7 @@ func TestHandle(t *testing.T) {
 			Scans: []domain.CompletedScan{
 				{
 					ScanID:    "1",
-					SiteID:    "1",
+					SiteID:    "11",
 					Timestamp: ts.Add(time.Second),
 				},
 			},
@@ -60,7 +60,7 @@ func TestHandle(t *testing.T) {
 				Response: []scanNotification{
 					{
 						ScanID: "1",
-						SiteID: "1",
+						SiteID: "11",
 					},
 				},
 			},
@@ -74,7 +74,7 @@ func TestHandle(t *testing.T) {
 			Scans: []domain.CompletedScan{
 				{
 					ScanID:    "1",
-					SiteID:    "1",
+					SiteID:    "11",
 					Timestamp: ts.Add(time.Second),
 				},
 			},
@@ -85,7 +85,7 @@ func TestHandle(t *testing.T) {
 				Response: []scanNotification{
 					{
 						ScanID: "1",
-						SiteID: "1",
+						SiteID: "11",
 					},
 				},
 			},
@@ -123,12 +123,12 @@ func TestHandle(t *testing.T) {
 			Scans: []domain.CompletedScan{
 				{
 					ScanID:    "1",
-					SiteID:    "1",
+					SiteID:    "11",
 					Timestamp: ts.Add(1 * time.Second),
 				},
 				{
 					ScanID:    "2",
-					SiteID:    "2",
+					SiteID:    "22",
 					Timestamp: ts.Add(2 * time.Second),
 				},
 			},
@@ -146,7 +146,7 @@ func TestHandle(t *testing.T) {
 			Scans: []domain.CompletedScan{
 				{
 					ScanID:    "1",
-					SiteID:    "1",
+					SiteID:    "11",
 					Timestamp: ts.Add(1 * time.Second),
 				},
 			},
@@ -208,12 +208,12 @@ func TestHandleSortOrder(t *testing.T) {
 			Scans: []domain.CompletedScan{
 				{
 					ScanID:    "1",
-					SiteID:    "1",
+					SiteID:    "11",
 					Timestamp: ts.Add(1 * time.Second),
 				},
 				{
 					ScanID:    "2",
-					SiteID:    "2",
+					SiteID:    "22",
 					Timestamp: ts.Add(2 * time.Second),
 				},
 			},
@@ -221,11 +221,11 @@ func TestHandleSortOrder(t *testing.T) {
 				Response: []scanNotification{
 					{
 						ScanID: "1",
-						SiteID: "1",
+						SiteID: "11",
 					},
 					{
 						ScanID: "2",
-						SiteID: "2",
+						SiteID: "22",
 					},
 				},
 			},
@@ -236,22 +236,22 @@ func TestHandleSortOrder(t *testing.T) {
 			Scans: []domain.CompletedScan{
 				{
 					ScanID:    "4",
-					SiteID:    "4",
+					SiteID:    "44",
 					Timestamp: ts.Add(4 * time.Second),
 				},
 				{
 					ScanID:    "1",
-					SiteID:    "1",
+					SiteID:    "11",
 					Timestamp: ts.Add(1 * time.Second),
 				},
 				{
 					ScanID:    "3",
-					SiteID:    "3",
+					SiteID:    "33",
 					Timestamp: ts.Add(3 * time.Second),
 				},
 				{
 					ScanID:    "2",
-					SiteID:    "2",
+					SiteID:    "22",
 					Timestamp: ts.Add(2 * time.Second),
 				},
 			},
@@ -259,19 +259,19 @@ func TestHandleSortOrder(t *testing.T) {
 				Response: []scanNotification{
 					{
 						ScanID: "1",
-						SiteID: "1",
+						SiteID: "11",
 					},
 					{
 						ScanID: "2",
-						SiteID: "2",
+						SiteID: "22",
 					},
 					{
 						ScanID: "3",
-						SiteID: "3",
+						SiteID: "33",
 					},
 					{
 						ScanID: "4",
-						SiteID: "4",
+						SiteID: "44",
 					},
 				},
 			},
@@ -282,22 +282,22 @@ func TestHandleSortOrder(t *testing.T) {
 			Scans: []domain.CompletedScan{
 				{
 					ScanID:    "4",
-					SiteID:    "4",
+					SiteID:    "44",
 					Timestamp: ts.Add(3 * time.Second),
 				},
 				{
 					ScanID:    "1",
-					SiteID:    "1",
+					SiteID:    "11",
 					Timestamp: ts.Add(1 * time.Second),
 				},
 				{
 					ScanID:    "3",
-					SiteID:    "3",
+					SiteID:    "33",
 					Timestamp: ts.Add(3 * time.Second),
 				},
 				{
 					ScanID:    "2",
-					SiteID:    "2",
+					SiteID:    "22",
 					Timestamp: ts.Add(2 * time.Second),
 				},
 			},
@@ -305,19 +305,19 @@ func TestHandleSortOrder(t *testing.T) {
 				Response: []scanNotification{
 					{
 						ScanID: "1",
-						SiteID: "1",
+						SiteID: "11",
 					},
 					{
 						ScanID: "2",
-						SiteID: "2",
+						SiteID: "22",
 					},
 					{
 						ScanID: "4",
-						SiteID: "4",
+						SiteID: "44",
 					},
 					{
 						ScanID: "3",
-						SiteID: "3",
+						SiteID: "33",
 					},
 				},
 			},

--- a/pkg/scanfetcher/nexpose.go
+++ b/pkg/scanfetcher/nexpose.go
@@ -3,6 +3,7 @@ package scanfetcher
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"io/ioutil"
 	"net/http"
 	"net/url"
@@ -127,6 +128,11 @@ func (n *NexposeClient) makePagedNexposeScanRequest(page int) (nexposeScanRespon
 	body, err := ioutil.ReadAll(res.Body)
 	if err != nil {
 		return nexposeScanResponse{}, err
+	}
+
+	if res.StatusCode != http.StatusOK {
+		return nexposeScanResponse{}, fmt.Errorf("unexpected response from nexpose scans api: %d %s",
+			res.StatusCode, string(body))
 	}
 
 	var scanResp nexposeScanResponse

--- a/pkg/scanfetcher/nexpose_test.go
+++ b/pkg/scanfetcher/nexpose_test.go
@@ -56,6 +56,7 @@ func TestNexposeClient_FetchScans(t *testing.T) {
 				&http.Response{
 					Body: ioutil.NopCloser(bytes.NewBuffer([]byte(fmt.Sprintf(testScanResponse,
 						afterTimestamp.Format(time.RFC3339Nano), finishedScanStatus, 0, 1)))),
+					StatusCode: http.StatusOK,
 				},
 			},
 			responseErrs: []error{nil},
@@ -74,14 +75,17 @@ func TestNexposeClient_FetchScans(t *testing.T) {
 				&http.Response{
 					Body: ioutil.NopCloser(bytes.NewBuffer([]byte(fmt.Sprintf(testScanResponse,
 						afterTimestamp.Format(time.RFC3339Nano), "running", 0, 3)))),
+					StatusCode: http.StatusOK,
 				},
 				&http.Response{
 					Body: ioutil.NopCloser(bytes.NewBuffer([]byte(fmt.Sprintf(testScanResponse,
 						afterTimestamp.Format(time.RFC3339Nano), finishedScanStatus, 1, 3)))),
+					StatusCode: http.StatusOK,
 				},
 				&http.Response{
 					Body: ioutil.NopCloser(bytes.NewBuffer([]byte(fmt.Sprintf(testScanResponse,
 						beforeTimestamp.Format(time.RFC3339Nano), finishedScanStatus, 2, 3)))),
+					StatusCode: http.StatusOK,
 				},
 			},
 			responseErrs: []error{nil, nil, nil},
@@ -100,6 +104,7 @@ func TestNexposeClient_FetchScans(t *testing.T) {
 				&http.Response{
 					Body: ioutil.NopCloser(bytes.NewBuffer([]byte(fmt.Sprintf(testScanResponse,
 						beforeTimestamp.Format(time.RFC3339Nano), finishedScanStatus, 0, 1)))),
+					StatusCode: http.StatusOK,
 				},
 			},
 			responseErrs: []error{nil},
@@ -121,6 +126,7 @@ func TestNexposeClient_FetchScans(t *testing.T) {
 				&http.Response{
 					Body: ioutil.NopCloser(bytes.NewBuffer([]byte(fmt.Sprintf(testScanResponse,
 						afterTimestamp.Format(time.RFC3339Nano), finishedScanStatus, 0, 2)))),
+					StatusCode: http.StatusOK,
 				},
 				nil,
 			},
@@ -134,6 +140,7 @@ func TestNexposeClient_FetchScans(t *testing.T) {
 				&http.Response{
 					Body: ioutil.NopCloser(bytes.NewBuffer([]byte(fmt.Sprintf(testScanResponse,
 						invalidTimestamp, finishedScanStatus, 0, 1)))),
+					StatusCode: http.StatusOK,
 				},
 			},
 			responseErrs: []error{nil},
@@ -146,13 +153,28 @@ func TestNexposeClient_FetchScans(t *testing.T) {
 				&http.Response{
 					Body: ioutil.NopCloser(bytes.NewBuffer([]byte(fmt.Sprintf(testScanResponse,
 						afterTimestamp.Format(time.RFC3339Nano), finishedScanStatus, 0, 2)))),
+					StatusCode: http.StatusOK,
 				},
 				&http.Response{
 					Body: ioutil.NopCloser(bytes.NewBuffer([]byte(fmt.Sprintf(testScanResponse,
 						invalidTimestamp, finishedScanStatus, 1, 2)))),
+					StatusCode: http.StatusOK,
 				},
 			},
 			responseErrs: []error{nil, nil},
+			expected:     nil,
+			expectErr:    true,
+		},
+		{
+			name: "response status not ok",
+			responses: []*http.Response{
+				&http.Response{
+					Body: ioutil.NopCloser(bytes.NewBuffer([]byte(fmt.Sprintf(testScanResponse,
+						afterTimestamp.Format(time.RFC3339Nano), finishedScanStatus, 0, 2)))),
+					StatusCode: http.StatusInternalServerError,
+				},
+			},
+			responseErrs: []error{nil},
 			expected:     nil,
 			expectErr:    true,
 		},
@@ -219,8 +241,11 @@ func TestNexposeClient_makePagedNexposeScanRequest(t *testing.T) {
 		expectErr   bool
 	}{
 		{
-			name:        "success",
-			response:    &http.Response{Body: ioutil.NopCloser(bytes.NewBuffer([]byte(testScanResponse)))},
+			name: "success",
+			response: &http.Response{
+				Body:       ioutil.NopCloser(bytes.NewBuffer([]byte(testScanResponse))),
+				StatusCode: http.StatusOK,
+			},
 			responseErr: nil,
 			expected: nexposeScanResponse{
 				Resources: []resource{
@@ -248,15 +273,21 @@ func TestNexposeClient_makePagedNexposeScanRequest(t *testing.T) {
 			expectErr:   true,
 		},
 		{
-			name:        "io read error",
-			response:    &http.Response{Body: ioutil.NopCloser(&errReader{Error: fmt.Errorf("io read error")})},
+			name: "io read error",
+			response: &http.Response{
+				Body:       ioutil.NopCloser(&errReader{Error: fmt.Errorf("io read error")}),
+				StatusCode: http.StatusOK,
+			},
 			responseErr: nil,
 			expected:    nexposeScanResponse{},
 			expectErr:   true,
 		},
 		{
-			name:        "invalid json error",
-			response:    &http.Response{Body: ioutil.NopCloser(bytes.NewBuffer([]byte(`{notjson}`)))},
+			name: "invalid json error",
+			response: &http.Response{
+				Body:       ioutil.NopCloser(bytes.NewBuffer([]byte(`{notjson}`))),
+				StatusCode: http.StatusOK,
+			},
 			responseErr: nil,
 			expected:    nexposeScanResponse{},
 			expectErr:   true,


### PR DESCRIPTION
Add a check for non-200 status codes in the response from the Nexpose API. Without this check, it's possible for error responses to be treated as successes.

Also fixes a bug where `completedScanToScanNotification` was using the scan ID in the site ID field of the scan event