### PR TITLE
Check HTTP producer response status code

### DIFF
--- a/pkg/producer/http.go
+++ b/pkg/producer/http.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
+	"io/ioutil"
 	"net/http"
 	"net/url"
 
@@ -35,5 +37,15 @@ func (p *HTTP) Produce(ctx context.Context, scan domain.CompletedScan) error {
 		return err
 	}
 	defer res.Body.Close()
+
+	resBody, err := ioutil.ReadAll(res.Body)
+	if err != nil {
+		return err
+	}
+
+	if res.StatusCode != http.StatusOK {
+		return fmt.Errorf("unexpected response from http producer: %d %s",
+			res.StatusCode, string(resBody))
+	}
 	return nil
 }

--- a/pkg/producer/http_test.go
+++ b/pkg/producer/http_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io/ioutil"
 	"net/http"
 	"net/url"
@@ -15,48 +16,82 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestProduceSuccess(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-	mockRT := NewMockRoundTripper(ctrl)
-
-	scan := domain.CompletedScan{
-		ScanID: "1",
-		SiteID: "2",
-	}
-
-	respJSON, _ := json.Marshal(scan)
-	respReader := bytes.NewReader(respJSON)
-	mockRT.EXPECT().RoundTrip(gomock.Any()).Return(&http.Response{
-		Body:       ioutil.NopCloser(respReader),
-		StatusCode: http.StatusOK,
-	}, nil)
-
-	endpoint, _ := url.Parse("http://localhost")
-	producer := &HTTP{
-		Client:   &http.Client{Transport: mockRT},
-		Endpoint: endpoint,
-	}
-	err := producer.Produce(context.Background(), scan)
-	require.Nil(t, err)
+type errReader struct {
+	Error error
 }
 
-func TestProduceError(t *testing.T) {
+func (r *errReader) Read(_ []byte) (int, error) {
+	return 0, r.Error
+}
+
+func TestHTTP_Produce(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	mockRT := NewMockRoundTripper(ctrl)
-
-	mockRT.EXPECT().RoundTrip(gomock.Any()).Return(nil, errors.New("HTTPError"))
 
 	scan := domain.CompletedScan{
 		ScanID: "1",
 		SiteID: "2",
 	}
+	respJSON, _ := json.Marshal(scan)
+	respReader := bytes.NewReader(respJSON)
 	endpoint, _ := url.Parse("http://localhost")
 	producer := &HTTP{
 		Client:   &http.Client{Transport: mockRT},
 		Endpoint: endpoint,
 	}
-	err := producer.Produce(context.Background(), scan)
-	require.NotNil(t, err)
+
+	tests := []struct {
+		name        string
+		response    *http.Response
+		responseErr error
+		expectErr   bool
+	}{
+		{
+			name: "success",
+			response: &http.Response{
+				Body:       ioutil.NopCloser(respReader),
+				StatusCode: http.StatusOK,
+			},
+			responseErr: nil,
+			expectErr:   false,
+		},
+		{
+			name:        "request error",
+			response:    nil,
+			responseErr: errors.New("HTTPError"),
+			expectErr:   true,
+		},
+		{
+			name: "non 200 status code",
+			response: &http.Response{
+				Body:       ioutil.NopCloser(respReader),
+				StatusCode: http.StatusNotFound,
+			},
+			responseErr: nil,
+			expectErr:   true,
+		},
+		{
+			name: "io read error",
+			response: &http.Response{
+				Body:       ioutil.NopCloser(&errReader{Error: fmt.Errorf("io read error")}),
+				StatusCode: http.StatusOK,
+			},
+			responseErr: nil,
+			expectErr:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockRT.EXPECT().RoundTrip(gomock.Any()).Return(tt.response, tt.responseErr)
+			err := producer.Produce(context.Background(), scan)
+			if tt.expectErr {
+				require.Error(t, err)
+				return
+			}
+			require.Nil(t, err)
+		})
+	}
+
 }

--- a/pkg/scanfetcher/nexpose.go
+++ b/pkg/scanfetcher/nexpose.go
@@ -160,8 +160,8 @@ func scanResourceToCompletedScan(resource resource, start time.Time) (domain.Com
 	}
 
 	// scans are fetched sorted by end time in descending order,
-	// so the first scan resource before the start time signals
-	// that no more scans need to be processed
+	// so the first scan resource before or equal to the start
+	// time signals that no more scans need to be processed
 	if endTime.Before(start) || endTime.Equal(start) {
 		return domain.CompletedScan{}, outOfRangeError{
 			ScanID:   strconv.Itoa(resource.ScanID),

--- a/pkg/scanfetcher/nexpose.go
+++ b/pkg/scanfetcher/nexpose.go
@@ -162,7 +162,7 @@ func scanResourceToCompletedScan(resource resource, start time.Time) (domain.Com
 	// scans are fetched sorted by end time in descending order,
 	// so the first scan resource before the start time signals
 	// that no more scans need to be processed
-	if endTime.Before(start) {
+	if endTime.Before(start) || endTime.Equal(start) {
 		return domain.CompletedScan{}, outOfRangeError{
 			ScanID:   strconv.Itoa(resource.ScanID),
 			SiteID:   strconv.Itoa(resource.SiteID),

--- a/pkg/scanfetcher/nexpose_test.go
+++ b/pkg/scanfetcher/nexpose_test.go
@@ -351,6 +351,17 @@ func TestScanResourceToCompletedScan(t *testing.T) {
 			err:      outOfRangeError{},
 		},
 		{
+			name: "scan out of range equal timestamp",
+			resource: resource{
+				EndTime: start.Format(time.RFC3339Nano),
+				ScanID:  1001,
+				SiteID:  1,
+				Status:  finishedScanStatus,
+			},
+			expected: domain.CompletedScan{},
+			err:      outOfRangeError{},
+		},
+		{
 			name: "scan not finished",
 			resource: resource{
 				EndTime: afterStart.Format(time.RFC3339Nano),


### PR DESCRIPTION
* Check status code returned by HTTP producer endpoint
* Rework producer tests to table tests
* Handle case where the most recent scan was already processed