### PR TITLE
Secd 797/add metrics to scan notifier

### DIFF
--- a/main.go
+++ b/main.go
@@ -50,6 +50,7 @@ func main() {
 		ScanFetcher:      nexposeClient,
 		Producer:         httpProducer,
 		LogFn:            domain.LoggerFromContext,
+		StatFn:           domain.StatFromContext,
 	}
 	handlers := map[string]serverfull.Function{
 		"notification": serverfull.NewFunction(notificationHandler.Handle),

--- a/pkg/handlers/v1/mock_stater_test.go
+++ b/pkg/handlers/v1/mock_stater_test.go
@@ -1,0 +1,23 @@
+package v1
+
+import (
+	"context"
+	"time"
+
+	"github.com/asecurityteam/nexpose-scan-notifier/pkg/domain"
+)
+
+type nopStat struct{}
+
+func (*nopStat) Gauge(stat string, value float64, tags ...string)        {}
+func (*nopStat) Count(stat string, count float64, tags ...string)        {}
+func (*nopStat) Histogram(stat string, value float64, tags ...string)    {}
+func (*nopStat) Timing(stat string, value time.Duration, tags ...string) {}
+func (*nopStat) AddTags(tags ...string)                                  {}
+func (*nopStat) GetTags() []string {
+	return []string{}
+}
+
+var testStat = &nopStat{}
+
+func MockStatFn(context.Context) domain.Stat { return testStat }

--- a/pkg/handlers/v1/notification.go
+++ b/pkg/handlers/v1/notification.go
@@ -3,6 +3,7 @@ package v1
 import (
 	"context"
 	"sort"
+	"time"
 
 	"github.com/asecurityteam/nexpose-scan-notifier/pkg/domain"
 	"github.com/asecurityteam/nexpose-scan-notifier/pkg/logs"
@@ -26,6 +27,7 @@ type NotificationHandler struct {
 	TimestampStorer  domain.TimestampStorer
 	Producer         domain.Producer
 	LogFn            domain.LogFn
+	StatFn           domain.StatFn
 }
 
 // Handle queries for completed scans since the last known successfully processed
@@ -33,6 +35,7 @@ type NotificationHandler struct {
 // of completed scans.
 func (h *NotificationHandler) Handle(ctx context.Context) (Output, error) {
 	logger := h.LogFn(ctx)
+	stater := h.StatFn(ctx)
 
 	lastScanTimestamp, err := h.TimestampFetcher.FetchTimestamp(ctx)
 	switch err.(type) {
@@ -56,6 +59,7 @@ func (h *NotificationHandler) Handle(ctx context.Context) (Output, error) {
 
 	scanNotifications := make([]scanNotification, len(scans))
 	for offset, scan := range scans {
+		scanCompletedTime := scan.Timestamp
 		// Produce completed scan events to a queue
 		err := h.Producer.Produce(ctx, scan)
 		if err != nil {
@@ -65,6 +69,7 @@ func (h *NotificationHandler) Handle(ctx context.Context) (Output, error) {
 		if err := h.TimestampStorer.StoreTimestamp(ctx, scan.Timestamp); err != nil {
 			return Output{}, err
 		}
+		stater.Timing("scannotificationdelay", time.Since(scanCompletedTime)*time.Millisecond)
 		scanNotifications[offset] = completedScanToScanNotification(scan)
 	}
 	return Output{Response: scanNotifications}, nil

--- a/pkg/handlers/v1/notification_test.go
+++ b/pkg/handlers/v1/notification_test.go
@@ -169,6 +169,7 @@ func TestHandle(t *testing.T) {
 		TimestampFetcher: mockTimestampFetcher,
 		TimestampStorer:  mockTimestampStorer,
 		Producer:         mockProducer,
+		StatFn:           MockStatFn,
 	}
 
 	for _, tt := range tc {
@@ -335,6 +336,7 @@ func TestHandleSortOrder(t *testing.T) {
 		TimestampFetcher: mockTimestampFetcher,
 		TimestampStorer:  mockTimestampStorer,
 		Producer:         mockProducer,
+		StatFn:           MockStatFn,
 	}
 
 	for _, tt := range tc {


### PR DESCRIPTION
Added metrics to measure:

1. The time it takes between when a Scan is completed in Nexpose and when a site is produced
2. A count of Scans completed

Adding stat metrics broke the unit tests unfortunately, so I added a mock of of stater to the unit tests

We are no longer considering Scan counts, http.client.timing.count 