### PR TITLE
Removed config for request body for /notification endpoint

### DIFF
--- a/api-inbound.yaml
+++ b/api-inbound.yaml
@@ -93,7 +93,6 @@ paths:
         lambda:
           arn: "notification"
           async: false
-          request: '#! json .Request.Body !#'
           success: '{"status": 200, "bodyPassthrough": true}'
           error: '{"status": 500, "bodyPassthrough": true}'
 components:


### PR DESCRIPTION
Small fix to the contract in api-inbound.yaml. I removed a line configuring a request body for the /notification endpoint, as the /notification endpoint does not take in a request body.