### PR TITLE
PSD-561 Fix blocked scans in first page failing entire request

### DIFF
--- a/pkg/scanfetcher/nexpose.go
+++ b/pkg/scanfetcher/nexpose.go
@@ -72,6 +72,8 @@ func (n *NexposeClient) FetchScans(ctx context.Context, ts time.Time) ([]domain.
 			completedScans = append(completedScans, completedScan)
 		case scanNotFinishedError:
 			// skip scans without a status of "finished"
+		case scanNameInBlocklistError:
+			//skip scans included by name in the blocklist
 		case outOfRangeError:
 			// since scans are returned in descending order by scan time, return
 			// the list of completed scans after finding the first scan outside


### PR DESCRIPTION
This fixes a bug in v0.5.0 that caused blocked scans detected on the first page of scan results to fail the entire request.