### PR TITLE
PSD-867 Add scanType, startTime, and endTime to scan notification payload

### DIFF
--- a/api-inbound.yaml
+++ b/api-inbound.yaml
@@ -100,7 +100,11 @@ components:
     ScanNotification:
       type: object
       required:
+        - scanID
         - siteID
+        - scanType
+        - startTime
+        - endTime
       properties:
         scanID:
           type: string
@@ -108,6 +112,22 @@ components:
         siteID:
           type: string
           description: The Nexpose site ID for the site that just got scanned.
+        scanType:
+          type: string
+          description: The type of scan that just completed.
+          enum:
+            - Agent
+            - Scheduled
+            - Manual
+            - Automated
+        startTime:
+          type: string
+          format: date-time
+          description: The start time of the scan in ISO8601 format.
+        endTime:
+          type: string
+          format: date-time
+          description: The end time of the scan in ISO8601 format.
     ScanNotifications:
       type: object
       properties:

--- a/api-outbound.yaml
+++ b/api-outbound.yaml
@@ -289,16 +289,30 @@ components:
       type: object
       description: A single scan element returned from the Nexpose scan API.
       properties:
+        id:
+          type: integer
+          description: The identifier of the scan.
+        scanType:
+          type: string
+          enum:
+            - Agent
+            - Scheduled
+            - Manual
+            - Automated
+        startTime:
+          type: string
+          format: date-time
+          description: The start time of the scan in ISO8601 format.
         endTime:
           type: string
           format: date-time
           description: The end time of the scan in ISO8601 format.
-        id:
-          type: integer
-          description: The identifier of the scan.
         siteId:
           type: integer
-          description: The identifier of the scan site.
+          description: The identifier of the scanned site.
+        scanName:
+          type: string
+          description: Name of the scan.
         status:
           type: string
           description: The scan status.
@@ -324,7 +338,11 @@ components:
     ScanNotification:
       type: object
       required:
+        - scanID
         - siteID
+        - scanType
+        - startTime
+        - endTime
       properties:
         scanID:
           type: string
@@ -332,6 +350,22 @@ components:
         siteID:
           type: string
           description: The Nexpose site ID for the site that just got scanned.
+        scanType:
+          type: string
+          description: The type of scan that just completed.
+          enum:
+            - Agent
+            - Scheduled
+            - Manual
+            - Automated
+        startTime:
+          type: string
+          format: date-time
+          description: The start time of the scan in ISO8601 format.
+        endTime:
+          type: string
+          format: date-time
+          description: The end time of the scan in ISO8601 format.
     Error:
       type: object
       properties:

--- a/pkg/domain/scanfetcher.go
+++ b/pkg/domain/scanfetcher.go
@@ -8,9 +8,10 @@ import (
 // CompletedScan represents identifiers for a completed Nexpose scan.
 type CompletedScan struct {
 	ScanID    string
-	ScanName  string
 	SiteID    string
-	Timestamp time.Time
+	ScanType  string
+	StartTime time.Time
+	EndTime   time.Time
 }
 
 // ScanFetcher fetchs scans completed from the provided time until now.

--- a/pkg/handlers/v1/notification_test.go
+++ b/pkg/handlers/v1/notification_test.go
@@ -15,10 +15,12 @@ import (
 func TestCompletedScanToscanNotification(t *testing.T) {
 	scanID := "1"
 	siteID := "1"
+	now := time.Now()
 	scan := completedScanToScanNotification(domain.CompletedScan{
 		SiteID:    siteID,
 		ScanID:    scanID,
-		Timestamp: time.Now(),
+		EndTime:   now,
+		StartTime: now.Add(time.Second * -10),
 	})
 	require.Equal(t, scanID, scan.ScanID)
 	require.Equal(t, siteID, scan.SiteID)
@@ -50,7 +52,9 @@ func TestHandle(t *testing.T) {
 				{
 					ScanID:    "1",
 					SiteID:    "11",
-					Timestamp: ts.Add(time.Second),
+					ScanType:  "Scheduled",
+					StartTime: ts.Add(time.Second),
+					EndTime:   ts.Add(time.Second * 10),
 				},
 			},
 			FetchScanErr:       nil,
@@ -59,8 +63,11 @@ func TestHandle(t *testing.T) {
 			Output: Output{
 				Response: []scanNotification{
 					{
-						ScanID: "1",
-						SiteID: "11",
+						ScanID:    "1",
+						SiteID:    "11",
+						ScanType:  "Scheduled",
+						StartTime: ts.Add(time.Second).Format(time.RFC3339Nano),
+						EndTime:   ts.Add(time.Second * 10).Format(time.RFC3339Nano),
 					},
 				},
 			},
@@ -75,7 +82,9 @@ func TestHandle(t *testing.T) {
 				{
 					ScanID:    "1",
 					SiteID:    "11",
-					Timestamp: ts.Add(time.Second),
+					ScanType:  "Scheduled",
+					StartTime: ts.Add(time.Second),
+					EndTime:   ts.Add(time.Second * 10),
 				},
 			},
 			FetchScanErr:       nil,
@@ -84,8 +93,11 @@ func TestHandle(t *testing.T) {
 			Output: Output{
 				Response: []scanNotification{
 					{
-						ScanID: "1",
-						SiteID: "11",
+						ScanID:    "1",
+						SiteID:    "11",
+						ScanType:  "Scheduled",
+						StartTime: ts.Add(time.Second).Format(time.RFC3339Nano),
+						EndTime:   ts.Add(time.Second * 10).Format(time.RFC3339Nano),
 					},
 				},
 			},
@@ -124,12 +136,14 @@ func TestHandle(t *testing.T) {
 				{
 					ScanID:    "1",
 					SiteID:    "11",
-					Timestamp: ts.Add(1 * time.Second),
+					StartTime: ts.Add(1 * time.Second),
+					EndTime:   ts.Add(2 * time.Second),
 				},
 				{
 					ScanID:    "2",
 					SiteID:    "22",
-					Timestamp: ts.Add(2 * time.Second),
+					StartTime: ts.Add(3 * time.Second),
+					EndTime:   ts.Add(4 * time.Second),
 				},
 			},
 			FetchScanErr:       nil,
@@ -147,7 +161,8 @@ func TestHandle(t *testing.T) {
 				{
 					ScanID:    "1",
 					SiteID:    "11",
-					Timestamp: ts.Add(1 * time.Second),
+					StartTime: ts.Add(1 * time.Second),
+					EndTime:   ts.Add(2 * time.Second),
 				},
 			},
 			FetchScanErr:       nil,
@@ -210,23 +225,33 @@ func TestHandleSortOrder(t *testing.T) {
 				{
 					ScanID:    "1",
 					SiteID:    "11",
-					Timestamp: ts.Add(1 * time.Second),
+					ScanType:  "Scheduled",
+					StartTime: ts,
+					EndTime:   ts.Add(1 * time.Second),
 				},
 				{
 					ScanID:    "2",
 					SiteID:    "22",
-					Timestamp: ts.Add(2 * time.Second),
+					ScanType:  "Scheduled",
+					StartTime: ts,
+					EndTime:   ts.Add(2 * time.Second),
 				},
 			},
 			Output: Output{
 				Response: []scanNotification{
 					{
-						ScanID: "1",
-						SiteID: "11",
+						ScanID:    "1",
+						SiteID:    "11",
+						ScanType:  "Scheduled",
+						StartTime: ts.Format(time.RFC3339Nano),
+						EndTime:   ts.Add(1 * time.Second).Format(time.RFC3339Nano),
 					},
 					{
-						ScanID: "2",
-						SiteID: "22",
+						ScanID:    "2",
+						SiteID:    "22",
+						ScanType:  "Scheduled",
+						StartTime: ts.Format(time.RFC3339Nano),
+						EndTime:   ts.Add(2 * time.Second).Format(time.RFC3339Nano),
 					},
 				},
 			},
@@ -238,41 +263,61 @@ func TestHandleSortOrder(t *testing.T) {
 				{
 					ScanID:    "4",
 					SiteID:    "44",
-					Timestamp: ts.Add(4 * time.Second),
+					ScanType:  "Scheduled",
+					StartTime: ts,
+					EndTime:   ts.Add(4 * time.Second),
 				},
 				{
 					ScanID:    "1",
 					SiteID:    "11",
-					Timestamp: ts.Add(1 * time.Second),
+					ScanType:  "Scheduled",
+					StartTime: ts,
+					EndTime:   ts.Add(1 * time.Second),
 				},
 				{
 					ScanID:    "3",
 					SiteID:    "33",
-					Timestamp: ts.Add(3 * time.Second),
+					ScanType:  "Scheduled",
+					StartTime: ts,
+					EndTime:   ts.Add(3 * time.Second),
 				},
 				{
 					ScanID:    "2",
 					SiteID:    "22",
-					Timestamp: ts.Add(2 * time.Second),
+					ScanType:  "Scheduled",
+					StartTime: ts,
+					EndTime:   ts.Add(2 * time.Second),
 				},
 			},
 			Output: Output{
 				Response: []scanNotification{
 					{
-						ScanID: "1",
-						SiteID: "11",
+						ScanID:    "1",
+						SiteID:    "11",
+						ScanType:  "Scheduled",
+						StartTime: ts.Format(time.RFC3339Nano),
+						EndTime:   ts.Add(1 * time.Second).Format(time.RFC3339Nano),
 					},
 					{
-						ScanID: "2",
-						SiteID: "22",
+						ScanID:    "2",
+						SiteID:    "22",
+						ScanType:  "Scheduled",
+						StartTime: ts.Format(time.RFC3339Nano),
+						EndTime:   ts.Add(2 * time.Second).Format(time.RFC3339Nano),
 					},
 					{
-						ScanID: "3",
-						SiteID: "33",
+						ScanID:    "3",
+						SiteID:    "33",
+						ScanType:  "Scheduled",
+						StartTime: ts.Format(time.RFC3339Nano),
+						EndTime:   ts.Add(3 * time.Second).Format(time.RFC3339Nano),
 					},
 					{
-						ScanID: "4",
-						SiteID: "44",
+						ScanID:    "4",
+						SiteID:    "44",
+						ScanType:  "Scheduled",
+						StartTime: ts.Format(time.RFC3339Nano),
+						EndTime:   ts.Add(4 * time.Second).Format(time.RFC3339Nano),
 					},
 				},
 			},
@@ -284,41 +329,61 @@ func TestHandleSortOrder(t *testing.T) {
 				{
 					ScanID:    "4",
 					SiteID:    "44",
-					Timestamp: ts.Add(3 * time.Second),
+					ScanType:  "Scheduled",
+					StartTime: ts,
+					EndTime:   ts.Add(3 * time.Second),
 				},
 				{
 					ScanID:    "1",
 					SiteID:    "11",
-					Timestamp: ts.Add(1 * time.Second),
+					ScanType:  "Scheduled",
+					StartTime: ts,
+					EndTime:   ts.Add(1 * time.Second),
 				},
 				{
 					ScanID:    "3",
 					SiteID:    "33",
-					Timestamp: ts.Add(3 * time.Second),
+					ScanType:  "Scheduled",
+					StartTime: ts,
+					EndTime:   ts.Add(3 * time.Second),
 				},
 				{
 					ScanID:    "2",
 					SiteID:    "22",
-					Timestamp: ts.Add(2 * time.Second),
+					ScanType:  "Scheduled",
+					StartTime: ts,
+					EndTime:   ts.Add(2 * time.Second),
 				},
 			},
 			Output: Output{
 				Response: []scanNotification{
 					{
-						ScanID: "1",
-						SiteID: "11",
+						ScanID:    "1",
+						SiteID:    "11",
+						ScanType:  "Scheduled",
+						StartTime: ts.Format(time.RFC3339Nano),
+						EndTime:   ts.Add(1 * time.Second).Format(time.RFC3339Nano),
 					},
 					{
-						ScanID: "2",
-						SiteID: "22",
+						ScanID:    "2",
+						SiteID:    "22",
+						ScanType:  "Scheduled",
+						StartTime: ts.Format(time.RFC3339Nano),
+						EndTime:   ts.Add(2 * time.Second).Format(time.RFC3339Nano),
 					},
 					{
-						ScanID: "4",
-						SiteID: "44",
+						ScanID:    "4",
+						SiteID:    "44",
+						ScanType:  "Scheduled",
+						StartTime: ts.Format(time.RFC3339Nano),
+						EndTime:   ts.Add(3 * time.Second).Format(time.RFC3339Nano),
 					},
 					{
-						ScanID: "3",
-						SiteID: "33",
+						ScanID:    "3",
+						SiteID:    "33",
+						ScanType:  "Scheduled",
+						StartTime: ts.Format(time.RFC3339Nano),
+						EndTime:   ts.Add(3 * time.Second).Format(time.RFC3339Nano),
 					},
 				},
 			},

--- a/pkg/producer/http.go
+++ b/pkg/producer/http.go
@@ -8,6 +8,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/url"
+	"time"
 
 	"github.com/asecurityteam/nexpose-scan-notifier/pkg/domain"
 )
@@ -19,15 +20,21 @@ type HTTP struct {
 }
 
 type scanPayload struct {
-	ScanID string `json:"scanID,omitempty"`
-	SiteID string `json:"siteID,omitempty"`
+	ScanID    string `json:"scanID,omitempty"`
+	SiteID    string `json:"siteID,omitempty"`
+	ScanType  string `json:"scanType,omitempty"`
+	StartTime string `json:"startTime,omitempty"`
+	EndTime   string `json:"endTime,omitempty"`
 }
 
 // Produce sends the completed scan event to an HTTP endpoint
 func (p *HTTP) Produce(ctx context.Context, scan domain.CompletedScan) error {
 	payload := scanPayload{
-		ScanID: scan.ScanID,
-		SiteID: scan.SiteID,
+		ScanID:    scan.ScanID,
+		SiteID:    scan.SiteID,
+		ScanType:  scan.ScanType,
+		StartTime: scan.StartTime.Format(time.RFC3339Nano),
+		EndTime:   scan.StartTime.Format(time.RFC3339Nano),
 	}
 	body, _ := json.Marshal(payload)
 	req, _ := http.NewRequest(http.MethodPost, p.Endpoint.String(), bytes.NewReader(body))

--- a/pkg/scanfetcher/nexpose.go
+++ b/pkg/scanfetcher/nexpose.go
@@ -34,11 +34,13 @@ type page struct {
 }
 
 type resource struct {
-	EndTime  string `json:"endTime"`
-	ScanID   int    `json:"id"`
-	ScanName string `json:"scanName"`
-	SiteID   int    `json:"siteId"`
-	Status   string `json:"status"`
+	ScanID    int    `json:"id"`
+	SiteID    int    `json:"siteId"`
+	ScanType  string `json:"scanType"`
+	StartTime string `json:"startTime"`
+	EndTime   string `json:"endTime"`
+	ScanName  string `json:"scanName"`
+	Status    string `json:"status"`
 }
 
 type nexposeScanResponse struct {
@@ -190,11 +192,18 @@ func (n *NexposeClient) scanResourceToCompletedScan(resource resource, start tim
 		}
 	}
 
+	// extract scan end time from scan resource
+	startTime, err := time.Parse(time.RFC3339Nano, resource.StartTime)
+	if err != nil {
+		return domain.CompletedScan{}, err
+	}
+
 	return domain.CompletedScan{
 		SiteID:    strconv.Itoa(resource.SiteID),
 		ScanID:    strconv.Itoa(resource.ScanID),
-		ScanName:  resource.ScanName,
-		Timestamp: endTime,
+		ScanType:  resource.ScanType,
+		StartTime: startTime,
+		EndTime:   endTime,
 	}, nil
 }
 

--- a/pkg/scanfetcher/nexpose_test.go
+++ b/pkg/scanfetcher/nexpose_test.go
@@ -31,7 +31,9 @@ func TestNexposeClient_FetchScans(t *testing.T) {
 		{
 			"resources": [
 				{
+					"startTime": "%s",
 					"endTime": "%s",
+					"scanType": "Scheduled",
 					"id": 1001,
 					"scanName": "%s",
 					"siteId": 1,
@@ -58,6 +60,7 @@ func TestNexposeClient_FetchScans(t *testing.T) {
 			responses: []*http.Response{
 				&http.Response{
 					Body: ioutil.NopCloser(bytes.NewBuffer([]byte(fmt.Sprintf(testScanResponse,
+						afterTimestamp.Add(time.Second*-10).Format(time.RFC3339Nano),
 						afterTimestamp.Format(time.RFC3339Nano), "Allowed Scan", finishedScanStatus, 0, 1)))),
 					StatusCode: http.StatusOK,
 				},
@@ -65,9 +68,10 @@ func TestNexposeClient_FetchScans(t *testing.T) {
 			responseErrs: []error{nil},
 			expected: []domain.CompletedScan{
 				{
-					Timestamp: afterTimestamp,
+					StartTime: afterTimestamp.Add(time.Second * -10),
+					EndTime:   afterTimestamp,
+					ScanType:  "Scheduled",
 					ScanID:    "1001",
-					ScanName:  "Allowed Scan",
 					SiteID:    "1",
 				},
 			},
@@ -78,16 +82,19 @@ func TestNexposeClient_FetchScans(t *testing.T) {
 			responses: []*http.Response{
 				&http.Response{
 					Body: ioutil.NopCloser(bytes.NewBuffer([]byte(fmt.Sprintf(testScanResponse,
+						afterTimestamp.Add(time.Second*-10).Format(time.RFC3339Nano),
 						afterTimestamp.Format(time.RFC3339Nano), "Allowed Scan", "running", 0, 3)))),
 					StatusCode: http.StatusOK,
 				},
 				&http.Response{
 					Body: ioutil.NopCloser(bytes.NewBuffer([]byte(fmt.Sprintf(testScanResponse,
+						afterTimestamp.Add(time.Second*-10).Format(time.RFC3339Nano),
 						afterTimestamp.Format(time.RFC3339Nano), "Allowed Scan", finishedScanStatus, 1, 3)))),
 					StatusCode: http.StatusOK,
 				},
 				&http.Response{
 					Body: ioutil.NopCloser(bytes.NewBuffer([]byte(fmt.Sprintf(testScanResponse,
+						beforeTimestamp.Add(time.Second*-10).Format(time.RFC3339Nano),
 						beforeTimestamp.Format(time.RFC3339Nano), "Allowed Scan", finishedScanStatus, 2, 3)))),
 					StatusCode: http.StatusOK,
 				},
@@ -95,9 +102,10 @@ func TestNexposeClient_FetchScans(t *testing.T) {
 			responseErrs: []error{nil, nil, nil},
 			expected: []domain.CompletedScan{
 				{
-					Timestamp: afterTimestamp,
+					StartTime: afterTimestamp.Add(time.Second * -10),
+					EndTime:   afterTimestamp,
+					ScanType:  "Scheduled",
 					ScanID:    "1001",
-					ScanName:  "Allowed Scan",
 					SiteID:    "1",
 				},
 			},
@@ -108,16 +116,19 @@ func TestNexposeClient_FetchScans(t *testing.T) {
 			responses: []*http.Response{
 				&http.Response{
 					Body: ioutil.NopCloser(bytes.NewBuffer([]byte(fmt.Sprintf(testScanResponse,
+						afterTimestamp.Add(time.Second*-10).Format(time.RFC3339Nano),
 						afterTimestamp.Format(time.RFC3339Nano), "Blocked Scan", finishedScanStatus, 0, 3)))),
 					StatusCode: http.StatusOK,
 				},
 				&http.Response{
 					Body: ioutil.NopCloser(bytes.NewBuffer([]byte(fmt.Sprintf(testScanResponse,
+						afterTimestamp.Add(time.Second*-10).Format(time.RFC3339Nano),
 						afterTimestamp.Format(time.RFC3339Nano), "Allowed Scan", finishedScanStatus, 1, 3)))),
 					StatusCode: http.StatusOK,
 				},
 				&http.Response{
 					Body: ioutil.NopCloser(bytes.NewBuffer([]byte(fmt.Sprintf(testScanResponse,
+						beforeTimestamp.Add(time.Second*-10).Format(time.RFC3339Nano),
 						beforeTimestamp.Format(time.RFC3339Nano), "Allowed Scan", finishedScanStatus, 2, 3)))),
 					StatusCode: http.StatusOK,
 				},
@@ -125,9 +136,10 @@ func TestNexposeClient_FetchScans(t *testing.T) {
 			responseErrs: []error{nil, nil, nil},
 			expected: []domain.CompletedScan{
 				{
-					Timestamp: afterTimestamp,
+					StartTime: afterTimestamp.Add(time.Second * -10),
+					EndTime:   afterTimestamp,
+					ScanType:  "Scheduled",
 					ScanID:    "1001",
-					ScanName:  "Allowed Scan",
 					SiteID:    "1",
 				},
 			},
@@ -138,16 +150,19 @@ func TestNexposeClient_FetchScans(t *testing.T) {
 			responses: []*http.Response{
 				&http.Response{
 					Body: ioutil.NopCloser(bytes.NewBuffer([]byte(fmt.Sprintf(testScanResponse,
+						afterTimestamp.Add(time.Second*-10).Format(time.RFC3339Nano),
 						afterTimestamp.Format(time.RFC3339Nano), "Allowed Scan", finishedScanStatus, 0, 3)))),
 					StatusCode: http.StatusOK,
 				},
 				&http.Response{
 					Body: ioutil.NopCloser(bytes.NewBuffer([]byte(fmt.Sprintf(testScanResponse,
+						afterTimestamp.Add(time.Second*-10).Format(time.RFC3339Nano),
 						afterTimestamp.Format(time.RFC3339Nano), "Blocked Scan", finishedScanStatus, 1, 3)))),
 					StatusCode: http.StatusOK,
 				},
 				&http.Response{
 					Body: ioutil.NopCloser(bytes.NewBuffer([]byte(fmt.Sprintf(testScanResponse,
+						beforeTimestamp.Add(time.Second*-10).Format(time.RFC3339Nano),
 						beforeTimestamp.Format(time.RFC3339Nano), "Allowed Scan", finishedScanStatus, 2, 3)))),
 					StatusCode: http.StatusOK,
 				},
@@ -155,9 +170,10 @@ func TestNexposeClient_FetchScans(t *testing.T) {
 			responseErrs: []error{nil, nil, nil},
 			expected: []domain.CompletedScan{
 				{
-					Timestamp: afterTimestamp,
+					StartTime: afterTimestamp.Add(time.Second * -10),
+					EndTime:   afterTimestamp,
+					ScanType:  "Scheduled",
 					ScanID:    "1001",
-					ScanName:  "Allowed Scan",
 					SiteID:    "1",
 				},
 			},
@@ -168,6 +184,7 @@ func TestNexposeClient_FetchScans(t *testing.T) {
 			responses: []*http.Response{
 				&http.Response{
 					Body: ioutil.NopCloser(bytes.NewBuffer([]byte(fmt.Sprintf(testScanResponse,
+						afterTimestamp.Add(time.Second*-10).Format(time.RFC3339Nano),
 						afterTimestamp.Format(time.RFC3339Nano), "Blocked Scan", finishedScanStatus, 0, 1)))),
 					StatusCode: http.StatusOK,
 				},
@@ -181,6 +198,7 @@ func TestNexposeClient_FetchScans(t *testing.T) {
 			responses: []*http.Response{
 				&http.Response{
 					Body: ioutil.NopCloser(bytes.NewBuffer([]byte(fmt.Sprintf(testScanResponse,
+						beforeTimestamp.Add(time.Second*-10).Format(time.RFC3339Nano),
 						beforeTimestamp.Format(time.RFC3339Nano), "Allowed Scan", finishedScanStatus, 0, 1)))),
 					StatusCode: http.StatusOK,
 				},
@@ -203,6 +221,7 @@ func TestNexposeClient_FetchScans(t *testing.T) {
 			responses: []*http.Response{
 				&http.Response{
 					Body: ioutil.NopCloser(bytes.NewBuffer([]byte(fmt.Sprintf(testScanResponse,
+						afterTimestamp.Add(time.Second*-10).Format(time.RFC3339Nano),
 						afterTimestamp.Format(time.RFC3339Nano), "Allowed Scan", finishedScanStatus, 0, 2)))),
 					StatusCode: http.StatusOK,
 				},
@@ -217,6 +236,7 @@ func TestNexposeClient_FetchScans(t *testing.T) {
 			responses: []*http.Response{
 				&http.Response{
 					Body: ioutil.NopCloser(bytes.NewBuffer([]byte(fmt.Sprintf(testScanResponse,
+						afterTimestamp.Add(time.Second*-10).Format(time.RFC3339Nano),
 						invalidTimestamp, "Allowed Scan", finishedScanStatus, 0, 1)))),
 					StatusCode: http.StatusOK,
 				},
@@ -230,11 +250,13 @@ func TestNexposeClient_FetchScans(t *testing.T) {
 			responses: []*http.Response{
 				&http.Response{
 					Body: ioutil.NopCloser(bytes.NewBuffer([]byte(fmt.Sprintf(testScanResponse,
+						afterTimestamp.Add(time.Second*-10).Format(time.RFC3339Nano),
 						afterTimestamp.Format(time.RFC3339Nano), "Allowed Scan", finishedScanStatus, 0, 2)))),
 					StatusCode: http.StatusOK,
 				},
 				&http.Response{
 					Body: ioutil.NopCloser(bytes.NewBuffer([]byte(fmt.Sprintf(testScanResponse,
+						afterTimestamp.Add(time.Second*-10).Format(time.RFC3339Nano),
 						invalidTimestamp, "Allowed Scan", finishedScanStatus, 1, 2)))),
 					StatusCode: http.StatusOK,
 				},
@@ -248,6 +270,7 @@ func TestNexposeClient_FetchScans(t *testing.T) {
 			responses: []*http.Response{
 				&http.Response{
 					Body: ioutil.NopCloser(bytes.NewBuffer([]byte(fmt.Sprintf(testScanResponse,
+						afterTimestamp.Add(time.Second*-10).Format(time.RFC3339Nano),
 						afterTimestamp.Format(time.RFC3339Nano), finishedScanStatus, 0, 2)))),
 					StatusCode: http.StatusInternalServerError,
 				},
@@ -293,12 +316,15 @@ func TestNexposeClient_makePagedNexposeScanRequest(t *testing.T) {
 	defer ctrl.Finish()
 
 	endpoint, _ := url.Parse("http://localhost")
-	ts := time.Date(2019, 05, 24, 00, 01, 00, 00, time.UTC)
+	endTS := time.Date(2019, 05, 24, 00, 01, 00, 00, time.UTC)
+	startTS := time.Date(2019, 05, 24, 00, 00, 00, 00, time.UTC)
 	testScanResponse := fmt.Sprintf(`
 		{
 			"resources": [
 				{
+					"startTime": "%s",
 					"endTime": "%s",
+					"scanType": "Scheduled",
 					"id": 1001,
 					"siteId": 1,
 					"scanName": "Allowed Scan",
@@ -311,7 +337,7 @@ func TestNexposeClient_makePagedNexposeScanRequest(t *testing.T) {
 				"totalResources": 200,
 				"totalPages": 200
 			}
-		}`, ts.Format(time.RFC3339Nano))
+		}`, startTS.Format(time.RFC3339Nano), endTS.Format(time.RFC3339Nano))
 
 	tests := []struct {
 		name        string
@@ -330,11 +356,13 @@ func TestNexposeClient_makePagedNexposeScanRequest(t *testing.T) {
 			expected: nexposeScanResponse{
 				Resources: []resource{
 					{
-						EndTime:  ts.Format(time.RFC3339Nano),
-						ScanID:   1001,
-						SiteID:   1,
-						ScanName: "Allowed Scan",
-						Status:   "running",
+						EndTime:   endTS.Format(time.RFC3339Nano),
+						StartTime: startTS.Format(time.RFC3339Nano),
+						ScanType:  "Scheduled",
+						ScanName:  "Allowed Scan",
+						ScanID:    1001,
+						SiteID:    1,
+						Status:    "running",
 					},
 				},
 				Page: page{
@@ -413,28 +441,31 @@ func TestScanResourceToCompletedScan(t *testing.T) {
 		{
 			name: "success",
 			resource: resource{
-				EndTime:  afterStart.Format(time.RFC3339Nano),
-				ScanID:   1001,
-				SiteID:   1,
-				ScanName: "Allowed Scan",
-				Status:   finishedScanStatus,
+				StartTime: afterStart.Add(time.Second * -10).Format(time.RFC3339Nano),
+				EndTime:   afterStart.Format(time.RFC3339Nano),
+				ScanID:    1001,
+				SiteID:    1,
+				ScanType:  "Agent",
+				Status:    finishedScanStatus,
 			},
 			expected: domain.CompletedScan{
 				SiteID:    strconv.Itoa(1),
 				ScanID:    strconv.Itoa(1001),
-				ScanName:  "Allowed Scan",
-				Timestamp: afterStart,
+				ScanType:  "Agent",
+				StartTime: afterStart.Add(time.Second * -10),
+				EndTime:   afterStart,
 			},
 			err: nil,
 		},
 		{
 			name: "scan out of range",
 			resource: resource{
-				EndTime:  beforeStart.Format(time.RFC3339Nano),
-				ScanID:   1001,
-				ScanName: "Allowed Scan",
-				SiteID:   1,
-				Status:   finishedScanStatus,
+				StartTime: beforeStart.Add(time.Second * -10).Format(time.RFC3339Nano),
+				EndTime:   beforeStart.Format(time.RFC3339Nano),
+				ScanID:    1001,
+				ScanType:  "Agent",
+				SiteID:    1,
+				Status:    finishedScanStatus,
 			},
 			expected: domain.CompletedScan{},
 			err:      outOfRangeError{},
@@ -442,11 +473,12 @@ func TestScanResourceToCompletedScan(t *testing.T) {
 		{
 			name: "scan out of range equal timestamp",
 			resource: resource{
-				EndTime:  start.Format(time.RFC3339Nano),
-				ScanID:   1001,
-				ScanName: "Allowed Scan",
-				SiteID:   1,
-				Status:   finishedScanStatus,
+				StartTime: start.Add(time.Second * -10).Format(time.RFC3339Nano),
+				EndTime:   start.Format(time.RFC3339Nano),
+				ScanID:    1001,
+				ScanType:  "Agent",
+				SiteID:    1,
+				Status:    finishedScanStatus,
 			},
 			expected: domain.CompletedScan{},
 			err:      outOfRangeError{},
@@ -454,11 +486,12 @@ func TestScanResourceToCompletedScan(t *testing.T) {
 		{
 			name: "scan not finished",
 			resource: resource{
-				EndTime:  afterStart.Format(time.RFC3339Nano),
-				ScanID:   1001,
-				SiteID:   1,
-				ScanName: "Allowed Scan",
-				Status:   "running",
+				StartTime: afterStart.Add(time.Second * -10).Format(time.RFC3339Nano),
+				EndTime:   afterStart.Format(time.RFC3339Nano),
+				ScanType:  "Agent",
+				ScanID:    1001,
+				SiteID:    1,
+				Status:    "running",
 			},
 			expected: domain.CompletedScan{},
 			err:      fmt.Errorf("scan not finished"),
@@ -466,11 +499,25 @@ func TestScanResourceToCompletedScan(t *testing.T) {
 		{
 			name: "end time not parseable",
 			resource: resource{
-				EndTime:  "",
-				ScanID:   1001,
-				ScanName: "Allowed Scan",
-				SiteID:   1,
-				Status:   finishedScanStatus,
+				StartTime: afterStart.Add(time.Second * -10).Format(time.RFC3339Nano),
+				EndTime:   "",
+				ScanType:  "Agent",
+				ScanID:    1001,
+				SiteID:    1,
+				Status:    finishedScanStatus,
+			},
+			expected: domain.CompletedScan{},
+			err:      fmt.Errorf("end time not parseable"),
+		},
+		{
+			name: "start time not parseable",
+			resource: resource{
+				EndTime:   afterStart.Format(time.RFC3339Nano),
+				StartTime: "",
+				ScanID:    1001,
+				ScanType:  "Agent",
+				SiteID:    1,
+				Status:    finishedScanStatus,
 			},
 			expected: domain.CompletedScan{},
 			err:      fmt.Errorf("end time not parseable"),
@@ -478,11 +525,12 @@ func TestScanResourceToCompletedScan(t *testing.T) {
 		{
 			name: "scan name in blocklist",
 			resource: resource{
-				EndTime:  beforeStart.Format(time.RFC3339Nano),
-				ScanID:   1001,
-				ScanName: "Blocked Scan",
-				SiteID:   1,
-				Status:   finishedScanStatus,
+				StartTime: beforeStart.Add(time.Second * -10).Format(time.RFC3339Nano),
+				EndTime:   beforeStart.Format(time.RFC3339Nano),
+				ScanID:    1001,
+				ScanType:  "Agent",
+				SiteID:    1,
+				Status:    finishedScanStatus,
 			},
 			expected: domain.CompletedScan{},
 			err:      scanNameInBlocklistError{},


### PR DESCRIPTION
This is needed so that the next link in the chain, nexpose-asset-producer, can use these fields to evaluate which assets to send down the pipeline for a given scan context of local or remote scan.

If the scan type is `Agent`, nexpose-asset-producer will produce assets with agent scans that have timestamps after the scan `startTime`, since these scan records in asset history do not have IDs.

If the scan type is anything else, nexpose-asset-producer will produce assets with remote scans with the given scan ID in their history.